### PR TITLE
Fixed depreciated API Endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,8 +59,8 @@ async function downloadCharacter(input) {
     const url = input.trim();
     console.debug('Custom content import started', url);
     let request = null;
-    // try /api/content/import first and then /import_custom
-    request = await fetch('/api/content/import', {
+    // try /api/content/importURL first and then /import_custom
+    request = await fetch('/api/content/importURL', {
         method: 'POST',
         headers: getRequestHeaders(),
         body: JSON.stringify({ url }),


### PR DESCRIPTION
I kept getting errors saying the  '/api/content/import' endpoint was depreciated, so I changed it to the endpoint it suggested to use instead.